### PR TITLE
Add CI workflow for testing and Docker publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,51 +2,71 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
-      - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
-  test:
+  tests:
+    name: Test suite
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
 
-      - name: Verify package imports
+      - name: Compile package
         run: python -m compileall opcua_sim
 
       - name: Run unit tests
-        run: python -m unittest discover
+        run: pytest
 
-  docker-build:
+  docker:
+    name: Build and push image
     runs-on: ubuntu-latest
-    needs: test
+    needs: tests
+    if: >-
+      needs.tests.result == 'success' &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Normalize repository name
+        id: repo_name
+        run: |
+          NORMALIZED_REPO=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+          echo "NORMALIZED_REPO=${NORMALIZED_REPO}" >> "$GITHUB_ENV"
+          echo "IMAGE_NAME=ghcr.io/${NORMALIZED_REPO}" >> "$GITHUB_ENV"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image
-        uses: docker/build-push-action@v5
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          context: .
-          push: false
-          tags: opc-ua-sim:ci
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare image tags
+        run: |
+          echo "LATEST_TAG=${IMAGE_NAME}:latest" >> "$GITHUB_ENV"
+          echo "SHA_TAG=${IMAGE_NAME}:${GITHUB_SHA}" >> "$GITHUB_ENV"
+
+      - name: Build and push image
+        run: |
+          docker buildx build \
+            --push \
+            --tag "$LATEST_TAG" \
+            --tag "$SHA_TAG" \
+            .


### PR DESCRIPTION
## Summary
- add a CI workflow that installs dependencies, compiles the package, and executes pytest on Python 3.11 for pushes, pull requests, and manual runs
- add a dependent Docker job that logs into GHCR, normalizes the repository name, tags the image with `latest` and the commit SHA, then builds and pushes when main/master tests pass

## Testing
- not run (workflow definition only)

------
https://chatgpt.com/codex/tasks/task_e_68cabf32bb348321b85d17da7892c60d