### PR TITLE
Grant workflow package write permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
## Summary
- add a permissions block to the CI workflow to allow writing packages while retaining read access to contents

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cad0db56308321b645e28935101aab